### PR TITLE
remove dotenv dependency from utils.py

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,5 @@
 from openai import OpenAI
-from dotenv import load_dotenv
 
-load_dotenv()
 client = OpenAI()
 
 def get_message(context):


### PR DESCRIPTION
This pull request includes a small change to the `utils.py` file. The change removes the `dotenv` library import and its usage, which is no longer needed.

* [`utils.py`](diffhunk://#diff-09d0cbaf891d623ac245ccf84485a687b554217349ca55557c60b33234b969aeL2-L4): Removed the import of `dotenv` and the `load_dotenv()` call.